### PR TITLE
feat: Umami v3 API support (v3.0.3) / Partial (migrate legacy) #43

### DIFF
--- a/.github/agent.md
+++ b/.github/agent.md
@@ -10,11 +10,11 @@
 
 **1 issue = 1 fichier `.github/issue_*.md`**
 
-- ✅ Toute modification/documentation se fait DANS ce fichier
-- ✅ Cocher tâches au fur et à mesure
-- ✅ Ajouter notes/découvertes en section dédiée
-- ❌ NE PAS créer de fichiers annexes (.github/PHASE*.md, UPDATE*.md, etc.)
-- ❌ NE PAS documenter ailleurs (sauf si explicitement demandé)
+- ✅ Tout DANS ce fichier: cocher tâches, ajouter notes
+- ❌ PAS de fichiers annexes (.github/PHASE*.md, UPDATE*.md)
+- ❌ PAS documenter ailleurs (sauf demande explicite)
+
+**Doc DRY/SRP**: 1 info = 1 endroit. README/MIGRATION_V3/CHANGELOG ont chacun leur scope (voir `/agent.md`)
 
 ## Structure issue_*.md
 

--- a/.github/breaking_changes_v3.md
+++ b/.github/breaking_changes_v3.md
@@ -1,0 +1,181 @@
+# Breaking Changes v2 → v3
+
+**Date**: 2026-01-19  
+**Test source**: `tests/manual/test_v3_cloud_auth.js`
+
+---
+
+## ✅ Compatible (no changes)
+
+### Authentication
+- ✅ `me()` - Structure identique
+- ✅ `login()` - Non testé mais devrait être OK
+
+### Websites
+- ✅ `websites()` - Structure identique
+  ```javascript
+  { id, name, domain, createdAt, ... }
+  ```
+
+---
+
+## ❌ Breaking Changes
+
+### 1. `websiteStats()` - Structure réponse modifiée
+
+**v2.17.x** (ancien):
+```javascript
+{
+  pageviews: { value: 3 },
+  visitors: { value: 3 },
+  visits: { value: 3 },
+  bounces: { value: 3 }
+}
+```
+
+**v3.0.x** (nouveau):
+```javascript
+{
+  pageviews: 3,        // Valeur directe (plus d'objet .value)
+  visitors: 3,
+  visits: 3,
+  bounces: 3,
+  totaltime: 0,
+  comparison: {        // NOUVEAU: comparaison période précédente
+    pageviews: 1,
+    visitors: 1,
+    visits: 1,
+    bounces: 1,
+    totaltime: 0
+  }
+}
+```
+
+**Impact**:
+- ❌ Code accédant à `stats.pageviews.value` → **ERREUR**
+- ✅ Solution: accéder directement à `stats.pageviews`
+
+**Migration**:
+```javascript
+// v2
+const views = stats.pageviews?.value || stats.pageviews || 0;
+
+// v3 (simplifié)
+const views = stats.pageviews || 0;
+```
+
+---
+
+## 🔍 Tests effectués
+
+### ✅ Endpoints testés (Cloud mode)
+- [x] `websiteStats()` - ⚠️ BREAKING (values direct, comparison added)
+- [x] `websitePageViews()` - ⚠️ BREAKING (wrapped in object)
+- [x] `websiteMetrics(type: url)` - ✅ Compatible
+- [x] `websiteMetrics(type: event)` - ✅ Compatible
+- [x] `websiteEvents()` - ✅ Compatible
+- [x] `websiteSessions()` - ✅ Compatible
+
+### Mode Hosted
+- [ ] `login()` - Fonctionne avec v3 ?
+- [ ] Endpoints identiques à Cloud ?
+
+### 2. `websitePageViews()` - Structure wrappée
+
+**v2.17.x** (supposé - à confirmer):
+```javascript
+[
+  { x: "2026-01-19T02:00:00Z", y: 1 },
+  { x: "2026-01-19T03:00:00Z", y: 1 }
+]
+```
+
+**v3.0.x** (confirmé):
+```javascript
+{
+  pageviews: [
+    { x: "2026-01-19T02:00:00Z", y: 1 },
+    { x: "2026-01-19T03:00:00Z", y: 1 }
+  ],
+  sessions: [        // NOUVEAU: sessions timeline
+    { x: "2026-01-19T02:00:00Z", y: 1 },
+    { x: "2026-01-19T03:00:00Z", y: 1 }
+  ]
+}
+```
+
+**Impact**:
+- ❌ Code attendant un Array direct → **ERREUR**
+- ✅ Solution: accéder à `result.pageviews`
+
+**Migration**:
+```javascript
+// v2
+const data = await client.websitePageViews(id, period);
+data.forEach(point => console.log(point.y));
+
+// v3
+const result = await client.websitePageViews(id, period);
+const data = result.pageviews;  // ← Access wrapper
+data.forEach(point => console.log(point.y));
+```
+
+---
+
+## ✅ Compatible (no changes needed)
+
+### 1. `websiteMetrics()` - Structure maintenue
+```javascript
+// v2 & v3 identique
+[
+  { x: "/page/url", y: 1 },
+  { x: "/other/page", y: 5 }
+]
+```
+
+### 2. `websiteEvents()` - Structure paginée maintenue
+```javascript
+// v2 & v3 identique
+{
+  data: [...],
+  count: 3,
+  page: 1,
+  pageSize: 10
+}
+```
+
+### 3. `websiteSessions()` - Structure paginée maintenue
+```javascript
+// v2 & v3 identique
+{
+  data: [...],
+  count: 3,
+  page: 1,
+  pageSize: 5
+}
+```
+
+---
+
+## 📊 Test results
+
+**Cloud mode v3.0.x**:
+```
+✅ me() - OK (compatible)
+✅ websites() - OK (compatible)
+⚠️  websiteStats() - BREAKING (values direct + comparison field)
+⚠️  websitePageViews() - BREAKING (wrapped in object + sessions)
+✅ websiteMetrics() - OK (compatible)
+✅ websiteEvents() - OK (compatible)
+✅ websiteSessions() - OK (compatible)
+
+Success rate: 67% compatible, 33% breaking changes
+```
+
+**Test files**: 
+- `tests/manual/test_v3_cloud_auth.js`
+- `tests/manual/test_v3_cloud_endpoints.js`
+
+**Test date**: 2026-01-19  
+**Umami Cloud version**: v3.0.x
+**Output log**: `test_v3_output.log`

--- a/.github/issue_umami_v3_support.md
+++ b/.github/issue_umami_v3_support.md
@@ -1,0 +1,380 @@
+# Issue: Umami v3.x API Support
+
+**Source**: [GitHub Issue #43](https://github.com/boly38/umami-api-client/issues/43)  
+**Statut**: 🚧 En cours  
+**Priorité**: High  
+**Effort estimé**: 2-3 jours
+
+---
+
+## Contexte
+
+- **Version actuelle**: `umami-api-client` v2.17.3 → cible Umami v2.17.x
+- **Version cible**: `umami-api-client` **v3.0.0** → Umami v3.0.3+ ONLY
+- **⚠️ BREAKING CHANGE**: Pas de rétro-compatibilité v2 (KISS principle)
+- **Release notes v3**: https://github.com/umami-software/umami/releases/tag/v3.0.0
+- **Blog post v3**: https://umami.is/blog/umami-v3
+
+**Decision**: Clean break → v3 only. Users needing v2 stay on `2.17.3`.
+
+---
+
+## Breaking Changes Umami v3
+
+### Base de données
+- ❌ **MySQL abandonné** (PostgreSQL only)
+
+### Nouvelles features v3
+- ✅ Links tracking (`/api/links`)
+- ✅ Pixels tracking (`/api/pixels`)
+- ✅ Segments (`/api/segments`)
+- ✅ Cohorts
+- ✅ Attribution reports
+- ✅ Distinct IDs (identification sessions)
+- ✅ Admin page (`/api/admin`)
+
+### Changements API
+- Nouvelle structure endpoints
+- Schémas réponses modifiés
+- Nouveaux paramètres filtres (query string universal)
+
+---
+
+## Plan d'action
+
+### ✅ Phase 1: Compatibilité API v3 - **COMPLÈTE**
+
+- [x] **Tester méthodes actuelles contre Umami v3.0.3**
+  - [x] `me()`, `websites()`, `websiteEvents()`, `websiteSessions()` - ✅ Compatible
+  - [x] `websiteStats()` - ⚠️ BREAKING (docé)
+  - [x] `websitePageViews()` - ⚠️ BREAKING (docé)
+  - [x] `websiteMetrics()` - ⚠️ type `url`→`path` (fixé)
+  
+- [x] **Breaking change: Metric type `url` → `path`**
+  - Umami v3 renamed `url` to `path` in EVENT_COLUMNS
+  - Fixed: Default type in `websiteMetrics()` changed to `path`
+  - Tests updated: All `type: 'url'` → `type: 'path'`
+  - Ref: [Umami constants.ts](https://github.com/umami-software/umami/blob/master/src/lib/constants.ts)
+  
+- [x] **Documentation complète**
+  - [x] `MIGRATION_V3.md` créé (breaking changes détaillés)
+  - [x] `CHANGELOG.md` créé (historique versions)
+  - [x] README.md mis à jour (version notice + lien migration)
+  - [x] `.github/breaking_changes_v3.md` (analyse technique)
+  
+- [x] **Code nettoyé**
+  - [x] Supprimé méthodes dépréciées: `getSites()`, `getStats()`, `getPageViews()`, `getEvents()`, `getMetrics()`, `verify()`
+  - [x] Tests 11/11 passent (hosted + cloud)
+  - [x] Test login err format v3
+
+**✅ Phase 1 = v3.0.3 publiable**
+
+### ✅ Phase 2: Nouvelles méthodes (features v3)
+
+**Status**: 📋 Ready to start (après Phase 1)  
+**Priority**: Medium  
+**Effort**: 2-3 days  
+**Version cible**: v3.1.0 (post v3.0.0)
+
+#### 🔗 Links API - Track short URLs and redirects
+
+**Endpoints**:
+- [ ] `links(options)` - GET /api/links
+- [ ] `createLink(data)` - POST /api/links
+- [ ] `getLink(linkId)` - GET /api/links/:linkId
+- [ ] `updateLink(linkId, data)` - POST /api/links/:linkId
+- [ ] `deleteLink(linkId)` - DELETE /api/links/:linkId
+- [ ] `linkStats(linkId, period, options)` - GET /api/links/:linkId/stats
+
+**Data structure**:
+```javascript
+// createLink
+{
+  url: "https://example.com/long-url",
+  description: "My link"
+}
+
+// Response
+{
+  id: "uuid",
+  url: "https://example.com/long-url",
+  description: "My link",
+  createdAt: "2025-01-19T..."
+}
+```
+
+**Tests**:
+- [ ] Create link
+- [ ] List links
+- [ ] Get link stats
+- [ ] Update/Delete link
+
+---
+
+#### 📊 Pixels API - Track with invisible images
+
+Track email open rates, external sites.
+
+**Endpoints**:
+- [ ] `pixels(options)` - GET /api/pixels
+- [ ] `createPixel(data)` - POST /api/pixels
+- [ ] `getPixel(pixelId)` - GET /api/pixels/:pixelId
+- [ ] `updatePixel(pixelId, data)` - POST /api/pixels/:pixelId
+- [ ] `deletePixel(pixelId)` - DELETE /api/pixels/:pixelId
+- [ ] `pixelStats(pixelId, period, options)` - GET /api/pixels/:pixelId/stats
+
+**Data structure**:
+```javascript
+// createPixel
+{
+  websiteId: "uuid",
+  name: "Newsletter open tracker"
+}
+
+// Response
+{
+  id: "uuid",
+  websiteId: "uuid",
+  name: "Newsletter open tracker",
+  createdAt: "2025-01-19T..."
+}
+```
+
+**Tests**:
+- [ ] Create pixel
+- [ ] List pixels
+- [ ] Get pixel stats
+- [ ] Update/Delete pixel
+
+---
+
+#### 🎯 Segments API - Save and reuse filter sets
+
+**Endpoints**:
+- [ ] `segments(options)` - GET /api/segments
+- [ ] `createSegment(data)` - POST /api/segments
+- [ ] `getSegment(segmentId)` - GET /api/segments/:segmentId
+- [ ] `updateSegment(segmentId, data)` - POST /api/segments/:segmentId
+- [ ] `deleteSegment(segmentId)` - DELETE /api/segments/:segmentId
+
+**Data structure**:
+```javascript
+// createSegment
+{
+  websiteId: "uuid",
+  name: "Windows users from US",
+  filters: {
+    os: "Windows",
+    country: "US"
+  }
+}
+```
+
+**Tests**:
+- [ ] Create segment
+- [ ] List segments
+- [ ] Apply segment as filter
+- [ ] Update/Delete segment
+
+---
+
+#### 👨‍💼 Admin API (optional)
+
+Admin-only endpoints for user/team/website management.
+
+**Endpoints**:
+- [ ] `adminWebsites(options)` - GET /api/admin/websites
+- [ ] `adminUsers(options)` - GET /api/admin/users
+- [ ] `adminTeams(options)` - GET /api/admin/teams
+
+**Requirements**:
+- Admin role required
+- Only for Hosted mode (Cloud has no admin API)
+
+**Tests**:
+- [ ] List all websites (admin)
+- [ ] List all users (admin)
+- [ ] Check permission denied for non-admin
+
+---
+
+#### 📝 Implementation Pattern
+
+All methods follow same pattern as existing endpoints:
+
+```javascript
+// In src/UmamiClient.js
+
+async links(options = { page: 1, pageSize: 10 }) {
+    const headers = this.authHeaders();
+    const url = `${this.umamiBaseUrl}/links?` + queryString.stringify(options);
+    const response = await fetch(url, { headers });
+    await assumeResponseSuccess(response, 'Unable to get links');
+    return await response.json();
+}
+
+async createLink(data) {
+    const headers = { ...this.authHeaders(), 'Content-Type': 'application/json' };
+    const response = await fetch(`${this.umamiBaseUrl}/links`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(data)
+    });
+    await assumeResponseSuccess(response, 'Unable to create link');
+    return await response.json();
+}
+
+// etc...
+```
+
+### ✅ Phase 3: Enhanced Features
+
+- [ ] **Distinct ID support**
+  - [ ] Ajouter paramètre `distinctId` dans méthodes tracking
+  - [ ] Documenter usage
+
+- [ ] **Nouveaux filtres query string**
+  - [ ] Adapter méthodes existantes pour nouveaux params v3
+  - [ ] Documenter nouveaux filtres
+
+- [ ] **Attribution reports**
+  - [ ] Implémenter méthode `attributionReport()`
+  - [ ] Documenter paramètres
+
+### ✅ Phase 4: Tests
+
+- [ ] **Mettre à jour mocks tests**
+  - [ ] Adapter réponses mockées v3
+  - [ ] Vérifier structure données
+
+- [ ] **Nouvelle suite tests v3**
+  - [ ] `tests/40_v3_links.test.js` (Links API)
+  - [ ] `tests/41_v3_pixels.test.js` (Pixels API)
+  - [ ] `tests/42_v3_segments.test.js` (Segments API)
+  - [ ] `tests/43_v3_admin.test.js` (Admin API)
+  - [ ] `tests/44_v3_methods.test.js` (distinct ID, attribution)
+
+- [ ] **Tests manuels**
+  - [ ] `tests/manual/test_v3_links.js`
+  - [ ] `tests/manual/test_v3_pixels.js`
+  - [ ] `tests/manual/test_v3_segments.js`
+
+- [ ] **Tests réels**
+  - [ ] Tester contre instance Umami Cloud v3
+  - [ ] Tester contre instance Umami Hosted v3.0.3
+
+### ✅ Phase 5: Release
+
+- [ ] **Documentation**
+  - [ ] Mettre à jour README.md:
+    - [ ] ⚠️ BREAKING CHANGE notice (v3 only, no v2 support)
+    - [ ] Migration guide v2 → v3 (stay on 2.17.3 or upgrade)
+    - [ ] Nouvelles features v3 (Links, Pixels, Segments)
+    - [ ] New methods section (Links, Pixels, Segments)
+    - [ ] Usage examples for new features
+  - [ ] Documenter nouvelles méthodes (JSDoc)
+  - [ ] CHANGELOG.md avec breaking changes
+  - [ ] Mettre à jour `MIGRATION_V3.md` avec nouvelles features
+
+- [ ] **Versioning**
+  - [ ] v3.0.0 - Base v3 compatibility + breaking changes fixes
+  - [ ] v3.1.0 - New features (Links, Pixels, Segments, Admin)
+  - [ ] Bump version `package.json` selon phase
+  - [ ] Supprimer code déprécié (`//~ DEPRECATED WORLD`)
+  - [ ] Nettoyer anciens workarounds v2
+
+- [ ] **Publication**
+  - [ ] `npm publish` v3.0.0 (base compatibility)
+  - [ ] `npm publish` v3.1.0 (new features)
+  - [ ] Créer GitHub Release v3.0.0
+  - [ ] Créer GitHub Release v3.1.0
+  - [ ] Release notes: breaking changes + migration guide
+  - [ ] Release notes v3.1.0: new features
+  - [ ] Mettre à jour dépendants (action-umami-report)
+
+---
+
+## Endpoints API v3 à implémenter
+
+```javascript
+// Links
+GET    /api/links                    → links()
+POST   /api/links                    → createLink(data)
+GET    /api/links/:linkId            → getLink(linkId)
+POST   /api/links/:linkId            → updateLink(linkId, data)
+DELETE /api/links/:linkId            → deleteLink(linkId)
+GET    /api/links/:linkId/stats      → linkStats(linkId, period, options)
+
+// Pixels
+GET    /api/pixels                   → pixels()
+POST   /api/pixels                   → createPixel(data)
+GET    /api/pixels/:pixelId          → getPixel(pixelId)
+POST   /api/pixels/:pixelId          → updatePixel(pixelId, data)
+DELETE /api/pixels/:pixelId          → deletePixel(pixelId)
+GET    /api/pixels/:pixelId/stats    → pixelStats(pixelId, period, options)
+
+// Segments
+GET    /api/segments                 → segments()
+POST   /api/segments                 → createSegment(data)
+GET    /api/segments/:segmentId      → getSegment(segmentId)
+POST   /api/segments/:segmentId      → updateSegment(segmentId, data)
+DELETE /api/segments/:segmentId      → deleteSegment(segmentId)
+
+// Admin (optionnel)
+GET    /api/admin/websites           → adminWebsites()
+GET    /api/admin/users              → adminUsers()
+GET    /api/admin/teams              → adminTeams()
+```
+
+---
+
+## ✅ Décisions prises (KISS)
+
+### 1. Versioning: **3.0.0** → **3.1.0** (staged release)
+- ✅ **v3.0.0** - Base compatibility (breaking changes fixes)
+- ✅ **v3.1.0** - New features (Links, Pixels, Segments)
+- ✅ **v3 ONLY** - Pas de rétro-compatibilité v2
+- ✅ Clean break, align avec Umami v3
+- ✅ Code simple (pas de dual support)
+- 📌 Users v2 **restent sur `2.17.3`**
+
+### 2. Support v2: **ABANDONNÉ**
+- ❌ Pas de maintenance v2.17.x
+- ❌ Pas de patches v2 (sauf sécurité critique)
+- 📌 Branch `v2` gelée sur 2.17.3
+
+### 3. Migration
+- README: **BREAKING CHANGE** notice bien visible
+- Guide migration: "Stay on 2.17.3 OR upgrade to 3.0.0"
+- Pas de période transition dual support
+
+---
+
+## Ressources
+
+- [Umami v3 Blog Post](https://umami.is/blog/umami-v3)
+- [Umami API Docs](https://umami.is/docs/api)
+- [Umami v3 Releases](https://github.com/umami-software/umami/releases?q=v3)
+- [Links API Docs](https://umami.is/docs/api/links)
+- [Pixels API Docs](https://umami.is/docs/api/pixels)
+- [Segments Docs](https://umami.is/docs/segments)
+- [Issue #42 - getVersion()](https://github.com/boly38/umami-api-client/issues/42)
+
+---
+
+## Checkboxes globales
+
+- [ ] Phase 1: Compatibilité API v3 (tests, breaking changes, cleanup v2) → **v3.0.0**
+- [ ] Phase 2: Nouvelles méthodes (Links, Pixels, Segments, Admin) → **v3.1.0**
+- [ ] Phase 3: Enhanced features (Distinct ID, filters, attribution) → **v3.1.0**
+- [ ] Phase 4: Tests (mocks v3, suite tests, tests réels)
+- [ ] Phase 5: Release 3.0.0 (doc BREAKING, cleanup, publish)
+- [ ] Phase 5: Release 3.1.0 (new features doc, publish)
+- [ ] Migration guide (v2.17.3 vs v3.0.0 vs v3.1.0)
+- [ ] Issue fermée ✅
+
+---
+
+**Date création**: 2026-01-19  
+**Dernière mise à jour**: 2026-01-19  
+**Assigné**: @boly38

--- a/.github/workflows/00_pnpm_audit.yml
+++ b/.github/workflows/00_pnpm_audit.yml
@@ -20,16 +20,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # https://github.com/pnpm/action-setup
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,16 @@ jobs:
 
     steps:
       - name: SETUP - Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # https://github.com/pnpm/action-setup
       - name: SETUP - Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
 
       - name: SETUP - Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/minor.yml
+++ b/.github/workflows/minor.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'npmjs'
           token: ${{ secrets.GH_ACTIONS_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'npmjs'
           token: ${{ secrets.GH_ACTIONS_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [3.0.3] - 2026-01-19
+
+### ⚠️ BREAKING CHANGES
+
+**This version targets Umami v3.x API only. Not compatible with Umami v2.x.**
+
+📚 **Full migration guide**: [MIGRATION_V3.md](./MIGRATION_V3.md)
+
+### Changed
+
+- **API alignment**: Client version now aligns with Umami server version (v3.0.3 → Umami v3.x)
+- **`websiteMetrics()`**: Default metric type changed from `url` to `path` (Umami v3 renamed this type)
+- **Response structures**: Adapted to match Umami v3 API responses:
+  - `websiteStats()`: Returns direct values instead of objects (e.g., `pageviews: 100` not `pageviews: {value: 100}`)
+  - `websitePageViews()`: Returns wrapped object with `pageviews` and `sessions` properties
+  - Login error format updated for Umami v3
+
+### Removed
+
+- **Deprecated methods** (use modern equivalents):
+  - `getSites()` → use `websites()`
+  - `getStats()` → use `websiteStats()`
+  - `getStatsForLast24h()` → use `websiteStats(id, '24h')`
+  - `getPageViews()` → use `websitePageViews()`
+  - `getPageViewsForLast24h()` → use `websitePageViews(id, '24h')`
+  - `getEvents()` → use `websiteEvents()`
+  - `getEventsForLast24h()` → use `websiteEvents(id, '24h')`
+  - `getMetrics()` → use `websiteMetrics()`
+  - `getMetricsForLast24h()` → use `websiteMetrics(id, '24h')`
+  - `getWebSiteDataForAPeriod()` → use `websiteData()`
+  - `verify()` → removed (unused)
+
+### Fixed
+
+- Test suite updated for Umami v3 API compatibility (11/11 tests passing)
+- Metric type `url` replaced with `path` in all tests and documentation
+
+### Migration
+
+**If you're using Umami v2.x**: Stay on `umami-api-client@2.17.3`
+
+**If you're using Umami v3.x**: Upgrade to `umami-api-client@3.0.3` and follow the [Migration Guide](./MIGRATION_V3.md)
+
+---
+
+## [2.17.3] - 2024-12-XX
+
+### Changed
+
+- Last version supporting Umami v2.x API
+- All deprecated methods still available but marked for removal in v3
+
+### Deprecated
+
+- All `get*()` methods deprecated in favor of modern `website*()` equivalents
+
+---
+
+## [2.17.0] - 2024-XX-XX
+
+### Added
+
+- Support for Umami v2.17.x API
+- Modern API methods: `websites()`, `websiteStats()`, `websitePageViews()`, etc.
+
+### Deprecated
+
+- Legacy methods marked as deprecated (still functional)
+
+---
+
+## Earlier versions
+
+See [GitHub Releases](https://github.com/boly38/umami-api-client/releases) for older version history.
+
+---
+
+## Version Support Matrix
+
+| umami-api-client | Umami Server | Status | Notes |
+|------------------|--------------|--------|-------|
+| **3.0.3+** | **Umami v3.x** | ✅ **Current** | Breaking changes from v2 |
+| 2.17.3 | Umami v2.x | ⚠️ **EOL** | No new features, security fixes only |
+| < 2.17.0 | Umami v2.x | ❌ **Unsupported** | Upgrade recommended |
+
+---
+
+**Legend**:
+- ✅ Current - Actively maintained
+- ⚠️ EOL - End of Life, minimal support
+- ❌ Unsupported - No support
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,17 +21,31 @@ cp ./env/initenv_project.template.sh ./env/initenv_project.dontpush.sh
 ````
 
 ## HowTo test
-* Then run manual test
 
+### Run all tests
 ````bash
 . ./env/initenv_project.dontpush.sh
 # run all tests
 pnpm run test
 # run all tests with code coverage
 pnpm run ci-test
-# run a single test file
-tst=10_negative pnpm run tst
 ````
+
+### Run single test file
+
+**Linux/Mac**:
+````bash
+. ./env/initenv_cloud.dontpush.sh
+TST=30_env_based_cloud_umami pnpm run xtst
+````
+
+**Windows**:
+````cmd
+call env\initenv_cloud.dontpush.sh
+set TST=30_env_based_cloud_umami && pnpm run tst
+````
+
+Available test files: `10_negative`, `20_env_based_hosted_umami`, `30_env_based_cloud_umami`
 
 ## HowTo release using Gren
 

--- a/MIGRATION_V3.md
+++ b/MIGRATION_V3.md
@@ -1,0 +1,293 @@
+# Migration Guide: v2.17.3 → v3.0.3
+
+**umami-api-client** v3.0.3 targets **Umami v3.x API**
+
+---
+
+## ⚠️ Breaking Changes
+
+### 1. **Version Alignment**
+
+Client versions now **align with Umami server versions**:
+
+| Client Version | Umami Server | Status |
+|----------------|--------------|--------|
+| v2.17.3 | Umami v2.17.x | ❌ EOL (stay on v2.17.3) |
+| **v3.0.3** | **Umami v3.0.x** | ✅ **Current** |
+
+**Migration path**:
+- **Option A**: Stay on `umami-api-client@2.17.3` if using Umami v2.x
+- **Option B**: Upgrade to `umami-api-client@3.0.3` if using Umami v3.x
+
+### 2. **Deprecated Methods Removed**
+
+All deprecated methods have been **removed** in v3.0.3:
+
+| ❌ Removed (v2) | ✅ Use instead (v3) |
+|----------------|---------------------|
+| `getSites(authData)` | `websites()` |
+| `getStats(authData, siteData, period)` | `websiteStats(siteId, period)` |
+| `getStatsForLast24h(authData, siteData)` | `websiteStats(siteId, '24h')` |
+| `getPageViews(authData, siteData, options, period)` | `websitePageViews(siteId, period, options)` |
+| `getPageViewsForLast24h(authData, siteData, options)` | `websitePageViews(siteId, '24h', options)` |
+| `getEvents(authData, siteData, options, period)` | `websiteEvents(siteId, period, options)` |
+| `getEventsForLast24h(authData, siteData, options)` | `websiteEvents(siteId, '24h', options)` |
+| `getMetrics(authData, siteData, options, period)` | `websiteMetrics(siteId, period, options)` |
+| `getMetricsForLast24h(authData, siteData, options)` | `websiteMetrics(siteId, '24h', options)` |
+| `getWebSiteDataForAPeriod(...)` | `websiteData(...)` |
+| `verify()` | *(removed - unused)* |
+
+**Migration example**:
+
+```javascript
+// v2.17.3 (deprecated)
+const authData = await client.login(user, pass);
+const sites = await client.getSites(authData);
+const stats = await client.getStatsForLast24h(authData, sites[0]);
+
+// v3.0.3 (clean API)
+await client.login(user, pass);
+const sites = await client.websites();
+const stats = await client.websiteStats(sites[0].id, '24h');
+```
+
+### 3. **API Response Structure Changes**
+
+Umami v3 API returns **different response structures**:
+
+#### `websiteStats()` - Direct values (not objects)
+
+**v2.17.x response** (Umami v2):
+```javascript
+{
+  pageviews: { value: 100 },
+  visitors: { value: 50 },
+  visits: { value: 75 },
+  bounces: { value: 10 }
+}
+```
+
+**v3.0.x response** (Umami v3):
+```javascript
+{
+  pageviews: 100,        // ← Direct number
+  visitors: 50,
+  visits: 75,
+  bounces: 10,
+  totaltime: 5000,
+  comparison: {          // ← NEW: period comparison
+    pageviews: 80,
+    visitors: 40,
+    visits: 60,
+    bounces: 8,
+    totaltime: 4000
+  }
+}
+```
+
+**Migration**:
+```javascript
+// v2 code
+const stats = await client.websiteStats(siteId, '24h');
+const views = stats.pageviews?.value || 0;
+
+// v3 code (simpler!)
+const stats = await client.websiteStats(siteId, '24h');
+const views = stats.pageviews || 0;
+const prevViews = stats.comparison?.pageviews || 0; // NEW: compare periods
+```
+
+#### `websitePageViews()` - Wrapped in object
+
+**v2.17.x response** (Umami v2):
+```javascript
+[
+  { x: "2026-01-19T00:00:00Z", y: 10 },
+  { x: "2026-01-19T01:00:00Z", y: 15 }
+]
+```
+
+**v3.0.x response** (Umami v3):
+```javascript
+{
+  pageviews: [                    // ← Wrapped
+    { x: "2026-01-19T00:00:00Z", y: 10 },
+    { x: "2026-01-19T01:00:00Z", y: 15 }
+  ],
+  sessions: [                     // ← NEW: sessions timeline
+    { x: "2026-01-19T00:00:00Z", y: 8 },
+    { x: "2026-01-19T01:00:00Z", y: 12 }
+  ]
+}
+```
+
+**Migration**:
+```javascript
+// v2 code
+const data = await client.websitePageViews(siteId, '24h');
+data.forEach(point => console.log(point.y));
+
+// v3 code
+const result = await client.websitePageViews(siteId, '24h');
+const pageviews = result.pageviews; // ← Access wrapper
+pageviews.forEach(point => console.log(point.y));
+
+// BONUS: sessions timeline now available
+const sessions = result.sessions;
+```
+
+---
+
+## ⚠️ Metric Type Changes
+
+### `websiteMetrics()` - Type parameter renamed
+
+Umami v3 renamed the `url` metric type to `path`:
+
+**v2.17.x metric types** (Umami v2):
+```javascript
+await client.websiteMetrics(siteId, '24h', { type: 'url' });      // ← Works in v2
+await client.websiteMetrics(siteId, '24h', { type: 'referrer' });
+```
+
+**v3.0.x metric types** (Umami v3):
+```javascript
+// ❌ FAILS in v3 - 400 Bad Request
+await client.websiteMetrics(siteId, '24h', { type: 'url' });
+
+// ✅ WORKS in v3 - Use 'path' instead
+await client.websiteMetrics(siteId, '24h', { type: 'path' });     // ← Renamed!
+await client.websiteMetrics(siteId, '24h', { type: 'referrer' });
+```
+
+**Available metric types in v3**:
+
+**Event columns** (page-related metrics):
+- ✅ `path` (was `url` in v2)
+- ✅ `entry`
+- ✅ `exit`
+- ✅ `referrer`
+- ✅ `domain`
+- ✅ `title`
+- ✅ `query`
+- ✅ `event`
+- ✅ `tag`
+- ✅ `hostname`
+
+**Session columns** (visitor-related metrics):
+- ✅ `browser`
+- ✅ `os`
+- ✅ `device`
+- ✅ `screen`
+- ✅ `language`
+- ✅ `country`
+- ✅ `city`
+- ✅ `region`
+
+**Special types**:
+- ✅ `channel` (new in v3)
+
+**Migration**:
+```javascript
+// v2 code
+const urlStats = await client.websiteMetrics(siteId, '24h', { type: 'url' });
+
+// v3 code - Replace 'url' with 'path'
+const pathStats = await client.websiteMetrics(siteId, '24h', { type: 'path' });
+```
+
+---
+
+## ✅ Compatible (No Changes Required)
+
+These methods have **identical responses** in v2 and v3:
+
+- ✅ `me()` - User info
+- ✅ `websites()` - Websites list
+- ✅ `websiteEvents()` - Paginated `{data, count, page, pageSize}`
+- ✅ `websiteSessions()` - Paginated `{data, count, page, pageSize}`
+
+**Note**: `websiteMetrics()` is compatible but requires the `type` parameter update (see above).
+
+---
+
+## 🆕 New Features in v3
+
+Umami v3 introduces **new tracking capabilities** (coming in `umami-api-client@3.1.0`):
+
+- 🔗 **Links** - Short URLs tracking
+- 🖼️ **Pixels** - Invisible image tracking (email open rates)
+- 📊 **Segments** - Save and reuse filter sets
+- 🔧 **Admin API** - User/team management (hosted only)
+
+See [issue #44](https://github.com/boly38/umami-api-client/issues/44) for implementation status.
+
+---
+
+## 📦 Installation
+
+```bash
+# Umami v3 users
+npm install umami-api-client@^3.0.3
+
+# Umami v2 users (stay on v2)
+npm install umami-api-client@^2.17.3
+```
+
+**Important**: Check your Umami server version before upgrading!
+
+---
+
+## 🧪 Testing Your Migration
+
+### 1. Check Umami server version
+- Cloud: Always latest (v3.x)
+- Hosted: Check your deployment version
+
+### 2. Update dependencies
+```bash
+npm install umami-api-client@^3.0.3
+```
+
+### 3. Update deprecated method calls
+Search your code for:
+- `getSites` → `websites`
+- `getStats` → `websiteStats`
+- `getPageViews` → `websitePageViews`
+- etc.
+
+### 4. Update response handling
+- `websiteStats()`: Remove `.value` access
+- `websitePageViews()`: Access `result.pageviews`
+
+### 5. Run tests
+```bash
+npm test
+```
+
+---
+
+## 🆘 Need Help?
+
+- 📖 [Full API Documentation](./README.md)
+- 🐛 [Report Issues](https://github.com/boly38/umami-api-client/issues)
+- 💬 [Discussions](https://github.com/boly38/umami-api-client/discussions)
+- 📝 [Umami v3 Release Notes](https://umami.is/blog/umami-v3)
+
+---
+
+## 📊 Quick Reference
+
+| Feature | v2.17.3 | v3.0.3 |
+|---------|---------|--------|
+| Umami v2.x support | ✅ | ❌ |
+| Umami v3.x support | ❌ | ✅ |
+| Deprecated methods | ⚠️ Working | ❌ Removed |
+| Response structure | v2 format | v3 format |
+| Version alignment | Unaligned | **Aligned with Umami** |
+
+---
+
+**Last updated**: 2026-01-19  
+**Client version**: v3.0.3  
+**Target Umami**: v3.0.x

--- a/README.md
+++ b/README.md
@@ -2,51 +2,45 @@
 
 [![NPM](https://nodei.co/npm/umami-api-client.png?compact=true)](https://npmjs.org/package/umami-api-client)
 
-Umami [ReST API](https://umami.is/docs/api).
+Umami [ReST API](https://umami.is/docs/api) client for Node.js.
 
-- compatible with JavaScript.
+## ⚠️ Version Notice
 
-Note that a typescript compatible API client exists (but deprecated/archived) : cf. https://github.com/jakobbouchard/umami-api-client
+**Current version: v3.0.3** - Targets **Umami v3.x API**
 
-## UmamiClient
-Features
+| umami-api-client | Umami Server | Status |
+|------------------|--------------|--------|
+| **v3.0.3** | **Umami v3.x** | ✅ **Current** |
+| v2.17.3 | Umami v2.x | ❌ EOL |
 
-using apiKey:
-- login
-- getSites
-- getStats, getPageViews, getEvents, getMetrics
+📚 **[Migration Guide v2 → v3](./MIGRATION_V3.md)** - Breaking changes & upgrade instructions
 
-accepted periods are : `1h`, `1d`, `7d`, `30d`, `31d`.
+---
 
-# Quick start
+## Features
 
-First, set up your environment :
+- ✅ **Dual mode**: Umami Cloud (API key) & Hosted (login/password)
+- ✅ **Complete API**: websites, stats, pageviews, events, metrics, sessions
+- ✅ **Periods**: `1h`, `24h`, `7d`, `1w`, `30d`, `1m`
+- ✅ **v3 compatible**: Works with Umami v3.0.x API
+- 🔜 **v3 features** (coming in v3.1.0): Links, Pixels, Segments APIs
 
-````bash
-cp ./env/initenv_cloud.template.sh ./env/initenv_cloud.dontpush.sh
-# update ./env/initenv_cloud.dontpush.sh
-. ./env/initenv_cloud.dontpush.sh
-````
-
-install umami-api-client
+## Installation
 
 ```bash
-pnpm install umami-api-client
+npm install umami-api-client@^3.0.3
 # or
-npm install umami-api-client
+pnpm add umami-api-client@^3.0.3
 ```
 
-then let's go, cf. example below.
+**Upgrading from v2.x?** Read the **[Migration Guide](./MIGRATION_V3.md)**
 
-### HowTo use UmamiClient with Umami Cloud server ?
-Umami Cloud is "Umami as a service" : cf. https://cloud.umami.is/
+---
 
-Rely on following mandatory variable ([setup your own](https://cloud.umami.is/api-keys)) : UMAMI_CLOUD_API_KEY
+## Quick Start
 
-NOTE: when an API key is set, the cloud mode is always activated (!) prior to hosted mode. To use hosted mode, you will have to unset UMAMI_CLOUD_API_KEY or use explicit config.
-
-
-[`$ node.exe ./tests/manual/cloud_sample.js`](./tests/manual/cloud_sample.js)
+### Umami Cloud (API Key)
+Umami Cloud: https://cloud.umami.is/ ([Get your API key](https://cloud.umami.is/api-keys))
 ````javascript
 import UmamiClient from 'umami-api-client';
 
@@ -73,15 +67,9 @@ const doIt = async () => {
 doIt().then(r => {});
 ````
 
-### HowTo use UmamiClient with an Umami hosted server ?
+### Umami Hosted (Self-hosted)
 
-**Umami hosted server** is a server with [umami product](https://github.com/umami-software/umami) hosted by you or by a company which is not Umami (or for ex. locally using docker).
-
-So a URL is available to query Umami hosted server (aka `UMAMI_SERVER`). Ex. `https://umami.exemple.com`
-
-By default, UmamiClient rely on following environment variables : `UMAMI_SERVER` `UMAMI_USER` `UMAMI_PASSWORD`
-
-[`$ node.exe ./tests/manual/host_sample.js`](./tests/manual/host_sample.js)
+Self-hosted Umami instance with login/password authentication.
 ````javascript
 import UmamiClient from 'umami-api-client';
 
@@ -107,21 +95,57 @@ const doIt = async () => {
 doIt().then(r => {});
 ````
 
-Note that relying on environment is not mandatory, you could use explicit config or arguments.
-ex.
+### Explicit Configuration (no env vars)
+
 ```javascript
-var client = new UmamiClient({server:'umami.exemple.com'});
-await client.login("admin","mySecret");
+// Cloud mode
+const client = new UmamiClient({ cloudApiKey: 'your-api-key' });
+
+// Hosted mode
+const client = new UmamiClient({ server: 'https://umami.example.com' });
+await client.login('admin', 'password');
 ```
 
-### HowTo better understand UmamiClient use ?
+---
 
-You could play mocha tests to get more examples (cf. [CONTRIBUTING](./CONTRIBUTING.md)).
+## API Methods
+
+### Authentication
+- `me()` - Get user info (Cloud mode)
+- `login(username, password)` - Login (Hosted mode)
+- `logout()` - Logout (Hosted mode)
+
+### Websites
+- `websites()` - List all websites
+- `selectSiteByDomain(sites, domain)` - Select site by domain
+
+### Statistics
+- `websiteStats(websiteId, period, options)` - Get website stats
+- `websitePageViews(websiteId, period, options)` - Get pageviews timeline
+- `websiteMetrics(websiteId, period, options)` - Get metrics (urls, referrers, browsers, etc.)
+- `websiteEvents(websiteId, period, options)` - Get events (paginated)
+- `websiteSessions(websiteId, period, options)` - Get sessions (paginated)
+
+### Periods
+Accepted values: `1h`, `24h`, `7d`, `1w`, `30d`, `1m`
+
+See [tests/manual/](./tests/manual/) for more examples.
+
+---
 
 
-## How to contribute
+## Documentation
 
-cf. [CONTRIBUTING](./CONTRIBUTING.md)
+- 📚 **[Migration Guide v2 → v3](./MIGRATION_V3.md)** - Breaking changes & upgrade path
+- 👨‍💻 **[Contributing Guide](./CONTRIBUTING.md)** - Setup, tests, release process
+- 🧪 **[Tests Documentation](./tests/TestsReadme.md)** - Running tests
+- 📝 **[Umami API Docs](https://umami.is/docs/api)** - Official API reference
+
+---
+
+## Contributing
+
+Contributions welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ### Services or activated bots
 
@@ -134,4 +158,10 @@ cf. [CONTRIBUTING](./CONTRIBUTING.md)
 - [Houndci](https://houndci.com/) : JavaScript  automated review (configured by `.hound.yml`)
 - [gren](https://github.com/github-tools/github-release-notes) : [Release notes](https://github.com/boly38/umami-api-client/releases) automation
 - Github pages [website](https://boly38.github.io/umami-api-client/) hosts some metrics for the main branch of this project: [code coverage](https://boly38.github.io/umami-api-client/)
+
+---
+
+## License
+
+MIT - See [LICENSE](./LICENSE)
 

--- a/agent.md
+++ b/agent.md
@@ -2,12 +2,18 @@
 
 ## Stack
 
-NPM package (ESM) - Umami API Client v2.17.3 → v3.x.x  
+NPM package (ESM) - Umami API Client **v3.0.3** (targets Umami v3.x API)  
 Node.js | node-fetch, query-string, winston | Mocha, Chai, c8
 
 ## Principes
 
 SOLID, KISS, DRY | Tests avant commit | pnpm only (sauf npm publish)
+
+**Doc DRY/SRP**: 1 info = 1 endroit, utiliser liens (pas duplication)
+- README.md: Quick Start + API ref
+- MIGRATION_V3.md: Breaking changes v2→v3
+- CHANGELOG.md: Historique versions
+- CONTRIBUTING.md: Setup dev/release
 
 ## Workflow
 
@@ -15,7 +21,7 @@ SOLID, KISS, DRY | Tests avant commit | pnpm only (sauf npm publish)
 2. Méthode API → Auth headers → Fetch → Validation réponse
 3. Tests Mocha (pas arrow functions: besoin `this.skip()`)
 4. Test manuel: `pnpm run cloud|hosted`
-5. Doc: README + JSDoc méthodes publiques
+5. Doc: JSDoc + mettre à jour fichier approprié (DRY/SRP)
 
 ## Structure
 
@@ -30,11 +36,12 @@ env/initenv_*.template.sh  ← Config templates
 ## Commandes
 
 ```bash
-pnpm install               # Setup
-pnpm test                  # Tests
-pnpm run ci-test           # Tests + coverage c8
-TST=20_env pnpm run tst    # Test ciblé
-pnpm run cloud|hosted      # Test manuel
+pnpm install                               # Setup
+pnpm test                                  # All tests
+pnpm run ci-test                           # Tests + coverage c8
+TST=30_env_based_cloud_umami pnpm run xtst # Test ciblé (Linux/Mac)
+TST=30_env_based_cloud_umami pnpm run tst  # Test ciblé (Windows)
+pnpm run cloud|hosted                      # Test manuel
 
 # Debug (env vars)
 UMAMI_CLIENT_DEBUG=true              # Global
@@ -46,6 +53,15 @@ UMAMI_CLIENT_DEBUG_RESPONSE=true     # Réponses
 
 Priorité outils IDE: Refactor, Search, Navigate, Git UI  
 Éviter: scripts bash (sed/awk/grep), npm (utiliser pnpm)
+
+**Modification fichiers problématiques**:  
+Si échec modification directe → Créer fichier temporaire + `mv` :  
+```bash
+cp original.md original_TEMP.md  # ou créer nouveau contenu
+# ... modifications ...
+rm original.md
+mv original_TEMP.md original.md
+```
 
 ## Conventions
 
@@ -68,12 +84,12 @@ me()                                   // Cloud only
 websites()                             // Liste sites
 websiteStats(id, period, options)
 websitePageViews(id, period, options)
-websiteMetrics(id, period, options)   // type: url|event
+websiteMetrics(id, period, options)   // type: path|event|referrer|browser|os|device|country|...
 websiteEvents(id, period, options)
 websiteSessions(id, period, options)
 ```
 
-**Déprécié v2 (à supprimer v3)**: `getSites()`, `getStats()`, `getPageViews()`... (cf. `//~ DEPRECATED WORLD`)
+**v3 Breaking**: Deprecated v2 methods removed. See [MIGRATION_V3.md](../MIGRATION_V3.md)
 
 ## Références
 

--- a/env/initenv_cloud.template.sh
+++ b/env/initenv_cloud.template.sh
@@ -3,3 +3,4 @@
 # Umami cloud - API access via api key - https://cloud.umami.is/api-keys
 unset UMAMI_SERVER UMAMI_USER UMAMI_PASSWORD
 export UMAMI_CLOUD_API_KEY="api_xxxyyyzzz"
+export UMAMI_TEST_CLOUD_API_KEY="api_xxxyyyzzz"

--- a/env/initenv_host.template.sh
+++ b/env/initenv_host.template.sh
@@ -2,6 +2,7 @@
 
 # Umami hosted server
 unset UMAMI_CLOUD_API_KEY
+unset UMAMI_TEST_CLOUD_API_KEY
 export UMAMI_SERVER="https://umami.replace-me.exemple.com"
 export UMAMI_USER="admin"
 export UMAMI_PASSWORD="12333321"

--- a/env/initenv_host_test.template.sh
+++ b/env/initenv_host_test.template.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Umami hosted server to test
+#  TST=20_env_based_hosted_umami pnpm run xtst
+unset UMAMI_CLOUD_API_KEY
+unset UMAMI_TEST_CLOUD_API_KEY
+unset UMAMI_SERVER
+unset UMAMI_USER
+unset UMAMI_PASSWORD
+export UMAMI_TEST_HOSTED_SERVER="https://umami.replace-me.exemple.com"
+export UMAMI_TEST_USER="admin"
+export UMAMI_TEST_PASSWORD="12333321"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umami-api-client",
-  "version": "2.17.3",
+  "version": "3.0.3",
   "description": "Umami API nodeJS client",
   "main": "./lib/export.js",
   "type": "module",
@@ -43,14 +43,14 @@
   },
   "dependencies": {
     "node-fetch": "^3.3.2",
-    "query-string": "^9.1.1",
-    "winston": "^3.11.0"
+    "query-string": "^9.3.1",
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "c8": "^10.1.3",
-    "chai": "^5.0.0",
-    "mocha": "^11.1.0",
+    "chai": "^6.2.2",
+    "mocha": "^11.7.5",
     "npm-force-resolutions": "^0.0.10"
   },
   "resolutions": {
@@ -59,5 +59,11 @@
   "jshintConfig": {
     "esversion": 11
   },
-  "packageManager": "pnpm@10.7.0+sha512.6b865ad4b62a1d9842b61d674a393903b871d9244954f652b8842c2b553c72176b278f64c463e52d40fff8aba385c235c8c9ecf5cc7de4fd78b8bb6d49633ab6"
+  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
+  "pnpm": {
+    "overrides": {
+      "glob@>=10.2.0 <10.5.0": ">=10.5.0",
+      "diff@<8.0.3": ">=8.0.3"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,15 +5,16 @@
   "main": "./lib/export.js",
   "type": "module",
   "scripts_doc": {
-    "ci-test": "c8 : config into '.nycrc' file. think about increasing functions coverage 60=>80 when deprecated functions will be removed"
+    "ci-test": "c8 : config into '.nycrc' file. Deprecated functions removed in v3."
   },
   "scripts": {
     "cloud": "node ./tests/manual/cloud_sample.js",
     "hosted": "node ./tests/manual/host_sample.js",
     "audit": "pnpm audit",
-    "test": "mocha tests/*.test.js",
+    "test": "mocha --timeout 180000 tests/*.test.js",
     "ci-test": "c8 pnpm run test",
-    "tst": "echo windows %TST% test&& mocha --trace-warnings --exit --timeout 180000 --unhandled-rejections=strict tests/%TST%.test.js"
+    "tst": "echo windows %TST% test&& mocha --trace-warnings --exit --timeout 180000 --unhandled-rejections=strict tests/%TST%.test.js",
+    "xtst": "echo linux $TST test && mocha --trace-warnings --exit --timeout 180000 --unhandled-rejections=strict tests/$TST.test.js"
   },
   "private": false,
   "author": "Boly38 <boly38@gmail.com>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   minimist: ^1.2.6
+  glob@>=10.2.0 <10.5.0: '>=10.5.0'
+  diff@<8.0.3: '>=8.0.3'
 
 importers:
 
@@ -15,11 +17,11 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       query-string:
-        specifier: ^9.1.1
-        version: 9.1.1
+        specifier: ^9.3.1
+        version: 9.3.1
       winston:
-        specifier: ^3.11.0
-        version: 3.17.0
+        specifier: ^3.19.0
+        version: 3.19.0
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.6
@@ -28,11 +30,11 @@ importers:
         specifier: ^10.1.3
         version: 10.1.3
       chai:
-        specifier: ^5.0.0
-        version: 5.2.0
+        specifier: ^6.2.2
+        version: 6.2.2
       mocha:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^11.7.5
+        version: 11.7.5
       npm-force-resolutions:
         specifier: ^0.0.10
         version: 0.0.10
@@ -47,8 +49,8 @@ packages:
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
-  '@dabh/diagnostics@2.0.3':
-    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
+  '@dabh/diagnostics@2.0.8':
+    resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -72,6 +74,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@so-ric/colorspace@1.1.6':
+    resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -80,10 +85,6 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
-
-  ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -101,16 +102,8 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
-  assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -118,16 +111,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
@@ -149,47 +134,44 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  chai@5.2.0:
-    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
-    engines: {node: '>=12'}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+  color-convert@3.1.3:
+    resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
+    engines: {node: '>=14.6'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
 
-  color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
-  colorspace@1.1.4:
-    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
+  color@5.0.3:
+    resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -202,8 +184,8 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -219,12 +201,8 @@ packages:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
     engines: {node: '>=14.16'}
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
-  diff@5.2.0:
-    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   eastasianwidth@0.2.0:
@@ -254,10 +232,6 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-
   filter-obj@5.1.0:
     resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
     engines: {node: '>=14.16'}
@@ -281,21 +255,12 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
-  fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
   has-flag@4.0.0:
@@ -312,28 +277,13 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  is-arrayish@0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
-
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
 
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -365,8 +315,8 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   json-format@1.0.1:
@@ -387,18 +337,11 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
-  loupe@3.1.3:
-    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
-
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
   minimatch@9.0.5:
@@ -409,8 +352,8 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mocha@11.1.0:
-    resolution: {integrity: sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==}
+  mocha@11.7.5:
+    resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
@@ -425,10 +368,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
 
   npm-force-resolutions@0.0.10:
     resolution: {integrity: sha512-Jscex+xIU6tw3VsyrwxM1TeT+dd9Fd3UOMAjy6J1TMpuYeEqg4LQZnATQO5vjPrsARm3und6zc6Dii/GUyRE5A==}
@@ -460,16 +399,11 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  pathval@2.0.0:
-    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
-    engines: {node: '>= 14.16'}
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
-  query-string@9.1.1:
-    resolution: {integrity: sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==}
+  query-string@9.3.1:
+    resolution: {integrity: sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==}
     engines: {node: '>=18'}
 
   randombytes@2.1.0:
@@ -479,9 +413,9 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -513,9 +447,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-swizzle@0.2.2:
-    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -569,10 +500,6 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
@@ -597,12 +524,12 @@ packages:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
 
-  winston@3.17.0:
-    resolution: {integrity: sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==}
+  winston@3.19.0:
+    resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
 
-  workerpool@6.5.1:
-    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+  workerpool@9.3.4:
+    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -642,9 +569,9 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@dabh/diagnostics@2.0.3':
+  '@dabh/diagnostics@2.0.8':
     dependencies:
-      colorspace: 1.1.4
+      '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
 
@@ -671,13 +598,16 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@so-ric/colorspace@1.1.6':
+    dependencies:
+      color: 5.0.3
+      text-hex: 1.0.0
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/mocha@10.0.10': {}
 
   '@types/triple-beam@1.3.5': {}
-
-  ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
 
@@ -689,28 +619,15 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
   argparse@2.0.1: {}
-
-  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
   balanced-match@1.0.2: {}
 
-  binary-extensions@2.3.0: {}
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
 
   browser-stdout@1.3.1: {}
 
@@ -732,32 +649,16 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  chai@5.2.0:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.1.3
-      pathval: 2.0.0
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  check-error@2.1.1: {}
-
-  chokidar@3.6.0:
+  chokidar@4.0.3:
     dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
+      readdirp: 4.1.2
 
   cliui@8.0.1:
     dependencies:
@@ -765,32 +666,26 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
-  color-name@1.1.3: {}
+  color-convert@3.1.3:
+    dependencies:
+      color-name: 2.1.0
 
   color-name@1.1.4: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
+  color-name@2.1.0: {}
 
-  color@3.2.1:
+  color-string@2.1.4:
     dependencies:
-      color-convert: 1.9.3
-      color-string: 1.9.1
+      color-name: 2.1.0
 
-  colorspace@1.1.4:
+  color@5.0.3:
     dependencies:
-      color: 3.2.1
-      text-hex: 1.0.0
+      color-convert: 3.1.3
+      color-string: 2.1.4
 
   convert-source-map@2.0.0: {}
 
@@ -802,7 +697,7 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  debug@4.4.0(supports-color@8.1.1):
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
@@ -812,9 +707,7 @@ snapshots:
 
   decode-uri-component@0.4.1: {}
 
-  deep-eql@5.0.2: {}
-
-  diff@5.2.0: {}
+  diff@8.0.3: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -834,10 +727,6 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   filter-obj@5.1.0: {}
 
@@ -859,16 +748,9 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  fsevents@2.3.3:
-    optional: true
-
   get-caller-file@2.0.5: {}
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
-  glob@10.4.5:
+  glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
@@ -885,21 +767,9 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  is-arrayish@0.3.2: {}
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
-  is-extglob@2.1.1: {}
-
   is-fullwidth-code-point@3.0.0: {}
 
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  is-number@7.0.0: {}
+  is-path-inside@3.0.3: {}
 
   is-plain-obj@2.1.0: {}
 
@@ -928,7 +798,7 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
@@ -954,17 +824,11 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
-  loupe@3.1.3: {}
-
   lru-cache@10.4.3: {}
 
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.1
-
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
@@ -972,25 +836,26 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mocha@11.1.0:
+  mocha@11.7.5:
     dependencies:
-      ansi-colors: 4.1.3
       browser-stdout: 1.3.1
-      chokidar: 3.6.0
-      debug: 4.4.0(supports-color@8.1.1)
-      diff: 5.2.0
+      chokidar: 4.0.3
+      debug: 4.4.3(supports-color@8.1.1)
+      diff: 8.0.3
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
-      glob: 10.4.5
+      glob: 10.5.0
       he: 1.2.0
-      js-yaml: 4.1.0
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.1
       log-symbols: 4.1.0
-      minimatch: 5.1.6
+      minimatch: 9.0.5
       ms: 2.1.3
+      picocolors: 1.1.1
       serialize-javascript: 6.0.2
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
-      workerpool: 6.5.1
+      workerpool: 9.3.4
       yargs: 17.7.2
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
@@ -1004,8 +869,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  normalize-path@3.0.0: {}
 
   npm-force-resolutions@0.0.10:
     dependencies:
@@ -1036,11 +899,9 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  pathval@2.0.0: {}
+  picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  query-string@9.1.1:
+  query-string@9.3.1:
     dependencies:
       decode-uri-component: 0.4.1
       filter-obj: 5.1.0
@@ -1056,9 +917,7 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
+  readdirp@4.1.2: {}
 
   require-directory@2.1.1: {}
 
@@ -1079,10 +938,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
 
   source-map-support@0.5.21:
     dependencies:
@@ -1132,14 +987,10 @@ snapshots:
   test-exclude@7.0.1:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 10.4.5
+      glob: 10.5.0
       minimatch: 9.0.5
 
   text-hex@1.0.0: {}
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
 
   triple-beam@1.4.1: {}
 
@@ -1163,10 +1014,10 @@ snapshots:
       readable-stream: 3.6.2
       triple-beam: 1.4.1
 
-  winston@3.17.0:
+  winston@3.19.0:
     dependencies:
       '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.3
+      '@dabh/diagnostics': 2.0.8
       async: 3.2.6
       is-stream: 2.0.1
       logform: 2.7.0
@@ -1177,7 +1028,7 @@ snapshots:
       triple-beam: 1.4.1
       winston-transport: 4.9.0
 
-  workerpool@6.5.1: {}
+  workerpool@9.3.4: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/UmamiClient.js
+++ b/src/UmamiClient.js
@@ -94,11 +94,7 @@ export default class UmamiClient {
         return authData;
     }
 
-    // TODO : POST /auth/verify - postponed in 2.0.17's next version
-    //  as there is bug on method to use (v2.0.17 - verify works only with GET)
-    async verify() {
-        throw new Error("NotYetAvailable - wait for https://github.com/umami-software/umami/issues/3339");
-    }
+
 
     /**
      * cloud mode only
@@ -210,7 +206,8 @@ export default class UmamiClient {
 
     // GET /api/website/{id}/metrics
     // https://umami.is/docs/api/website-stats-api#get-apiwebsiteswebsiteidmetrics
-    async websiteMetrics(websiteId, period = "24h", options = {type: 'url', unit: 'hour', timezone: 'Europe/Paris'}) {
+    // Note: In Umami v3, 'url' type was renamed to 'path'
+    async websiteMetrics(websiteId, period = "24h", options = {type: 'path', unit: 'hour', timezone: 'Europe/Paris'}) {
         return this.websiteData(websiteId, 'metrics', period, options);
     }
 
@@ -227,88 +224,6 @@ export default class UmamiClient {
             throw new Error(`Invalid ${name} UID format. Must be a valid UUID-like string.`);
         }
         return true;
-    }
-
-    //~ DEPRECATED WORLD
-
-    /**
-     * @deprecated : use now websites() - to be removed in futur version
-     */
-    async getSites(authData) {
-        this.lastAuthData = authData;
-        return this.websites();
-    }
-
-    /**
-     * @deprecated : please use websiteStats(id, period) - to be removed in futur version
-     */
-    async getStats(authData, siteData, period = '24h') {
-        this.lastAuthData = authData;
-        return await this.websiteStats(siteData.id, period);
-    }
-
-    /**
-     * @deprecated : please use websiteStats(id, '24h') - to be removed in futur version
-     */
-    async getStatsForLast24h(authData, siteData) {
-        this.lastAuthData = authData;
-        return await this.websiteStats(siteData.id, '24h');
-    }
-
-    /**
-     * @deprecated : please use websitePageViews(id, period, options) - to be removed in futur version
-     */
-    async getPageViews(authData, siteData, options = {unit: 'hour', timezone: 'Europe/Paris'}, period = '24h') {
-        this.lastAuthData = authData;
-        return await this.websitePageViews(siteData.id, period, options);
-    }
-
-    /**
-     * @deprecated : please use websitePageViews(id, '24h', options) - to be removed in futur version
-     */
-    async getPageViewsForLast24h(authData, siteData, options = {unit: 'hour', timezone: 'Europe/Paris'}) {
-        this.lastAuthData = authData;
-        return await this.websitePageViews(siteData.id, '24h', options);
-    }
-
-    /**
-     * @deprecated : please use websiteEvents(id, '24h', options) - to be removed in futur version
-     */
-    async getEventsForLast24h(authData, siteData, options = {unit: 'hour', timezone: 'Europe/Paris'}) {
-        this.lastAuthData = authData;
-        return await this.websiteEvents(siteData.id, '24h', options);
-    }
-
-    /**
-     * @deprecated : please use websiteEvents(id, period, options) - to be removed in futur version
-     */
-    async getEvents(authData, siteData, options = {unit: 'hour', timezone: 'Europe/Paris'}, period = '24h') {
-        this.lastAuthData = authData;
-        return await this.websiteEvents(siteData.id, period, options);
-    }
-
-    /**
-     * @deprecated : use now websiteStats(...) or websitePageviews - to be removed in futur version
-     */
-    async getWebSiteDataForAPeriod(authData, siteData, dataDescription = 'stats', dataPath = '/stats', period = '24h', options = {}) {
-        this.lastAuthData = authData;
-        return this.websiteData(siteData.id, dataPath.split('/')[0], period, options);
-    }
-
-    /**
-     * @deprecated : use now websiteMetrics(siteData.id, '24h', options) - to be removed in futur version
-     */
-    async getMetricsForLast24h(authData, siteData, options) {
-        this.lastAuthData = authData;
-        return await this.websiteMetrics(siteData.id, '24h', options);
-    }
-
-    /**
-     * @deprecated : use now websiteMetrics(siteData.id, period, options) - to be removed in futur version
-     */
-    async getMetrics(authData, siteData, options, period = '24h') {
-        this.lastAuthData = authData;
-        return await this.websiteMetrics(siteData.id, period, options);
     }
 
 }
@@ -328,17 +243,7 @@ const assumeResponseSuccess = async function (response, errorMsg) {
         throw new Error(`${response.status} - ${errorMsg} - ` + await response.text());
     }
 };
-const givenAuthData = (authData) => {
-    if (!isSet(authData) || !isSet(authData.token)) {
-        throw new Error("expect valid auth data to query api");
-    }
-};
-const givenAuthAndSiteData = (authData, siteData) => {
-    givenAuthData(authData);
-    if (!isUmamiSiteData(siteData)) {
-        throw new Error("Unexpected site data provided");
-    }
-};
+
 const HOUR_IN_MS = (60000 * 60);
 const DAY_IN_MS = (HOUR_IN_MS * 24);
 const HOUR_PERIODS = ['1h', '1hour', '60min'];

--- a/tests/30_env_based_cloud_umami.test.js
+++ b/tests/30_env_based_cloud_umami.test.js
@@ -125,10 +125,11 @@ describe("env based UmamiClient targeting umami CLOUD", function () {
         assumeListResult(`${siteData.name}'s events 30 days`, result?.data, mayBeEmpty, verbose);
     });
 
-    // all types are : ['url', 'referrer', 'browser', 'os', 'device', 'country', 'event']
+    // all types are : ['path', 'referrer', 'browser', 'os', 'device', 'country', 'event']
+    // Note: 'url' was renamed to 'path' in Umami v3
     it("should get /website/{id}/metrics for 24h", async function () {
         expectTestInputOrSkip("siteData", siteData, this.skip.bind(this));
-        for (const type of ['url', 'referrer']) {
+        for (const type of ['path', 'referrer']) {
             const result = await client.websiteMetrics(siteData.id, '24h', {type});
             assumeListResult(`${siteData.name}'s 24h metrics type:${type}`, result, mayBeEmpty, verbose);
         }

--- a/tests/TestsReadme.md
+++ b/tests/TestsReadme.md
@@ -1,4 +1,45 @@
-# DEV note about tests 
-- don't duplicate, factorize
-- `mocha` : don't use arrow function https://mochajs.org/#arrow-functions 
-(ex. `this.skip()` require mocha context)
+# DEV note about tests
+
+## Rules
+- Don't duplicate, factorize
+- `mocha`: Don't use arrow functions https://mochajs.org/#arrow-functions  
+  (ex. `this.skip()` requires mocha context)
+
+## Running tests
+
+### All tests
+```bash
+pnpm test              # Run all tests
+pnpm run ci-test       # Run all tests + coverage (c8)
+```
+
+### Single test file
+
+**Linux/Mac**:
+```bash
+TST=30_env_based_cloud_umami pnpm run xtst
+```
+
+**Windows**:
+```cmd
+set TST=30_env_based_cloud_umami && pnpm run tst
+```
+
+### Available test files
+- `10_negative.test.js` - Negative tests (errors expected)
+- `20_env_based_hosted_umami.test.js` - Hosted mode tests
+- `30_env_based_cloud_umami.test.js` - Cloud mode tests
+
+### Environment setup
+
+**Cloud mode**:
+```bash
+source env/initenv_cloud.dontpush.sh
+TST=30_env_based_cloud_umami pnpm run xtst
+```
+
+**Hosted mode**:
+```bash
+source env/initenv_host.dontpush.sh
+TST=20_env_based_hosted_umami pnpm run xtst
+```

--- a/tests/manual/test_v3_cloud_auth.js
+++ b/tests/manual/test_v3_cloud_auth.js
@@ -1,0 +1,74 @@
+/**
+ * Test manual: Auth Cloud mode avec Umami v3
+ * 
+ * Setup:
+ * export UMAMI_CLOUD_API_KEY="your-api-key"
+ * 
+ * Run:
+ * node tests/manual/test_v3_cloud_auth.js
+ */
+
+import UmamiClient from '../../lib/export.js';
+
+const testCloudAuth = async () => {
+    console.log('🧪 Test Umami v3 Cloud Auth\n');
+    
+    try {
+        // 1. Init client
+        const client = new UmamiClient();
+        console.log('✅ Client initialized (Cloud mode)');
+        console.log(`   Server: ${client.umamiBaseUrl}\n`);
+        
+        // 2. Test me() - validate API key
+        console.log('🔑 Testing me() endpoint...');
+        const identity = await client.me();
+        
+        console.log('✅ Authentication successful!');
+        console.log('\n📋 User info:');
+        console.log(JSON.stringify(identity?.user, null, 2));
+        
+        // 3. Test websites()
+        console.log('\n🗂️  Testing websites() endpoint...');
+        const websites = await client.websites();
+        
+        console.log(`✅ Found ${websites.length} website(s)`);
+        
+        if (websites.length > 0) {
+            const site = websites[0];
+            console.log('\n📊 First website:');
+            console.log(`   ID: ${site.id}`);
+            console.log(`   Name: ${site.name}`);
+            console.log(`   Domain: ${site.domain}`);
+            console.log(`   Created: ${site.createdAt}`);
+            
+            // 4. Test websiteStats() - basic v3 endpoint
+            console.log('\n📈 Testing websiteStats() endpoint...');
+            const stats = await client.websiteStats(site.id, '24h');
+            
+            console.log('✅ Stats retrieved successfully!');
+            console.log('\n📊 24h Stats:');
+            console.log(`   PageViews: ${stats.pageviews?.value || stats.pageviews || 'N/A'}`);
+            console.log(`   Visitors: ${stats.visitors?.value || stats.visitors || 'N/A'}`);
+            console.log(`   Visits: ${stats.visits?.value || stats.visits || 'N/A'}`);
+            console.log(`   Bounce rate: ${stats.bounces?.value || stats.bounces || 'N/A'}`);
+            
+            // Debug: show full stats structure
+            console.log('\n🔍 Full stats structure (v3):');
+            console.log(JSON.stringify(stats, null, 2));
+        }
+        
+        console.log('\n\n✅ ALL TESTS PASSED! Umami v3 Cloud is working! 🎉');
+        
+    } catch (error) {
+        console.error('\n❌ TEST FAILED!');
+        console.error(`Error: ${error.message}`);
+        console.error('\nStack:', error.stack);
+        process.exit(1);
+    }
+};
+
+// Run test
+testCloudAuth().then(() => {
+    console.log('\n✨ Test completed successfully');
+    process.exit(0);
+});

--- a/tests/manual/test_v3_cloud_endpoints.js
+++ b/tests/manual/test_v3_cloud_endpoints.js
@@ -1,0 +1,239 @@
+/**
+ * Test manual: Tous les endpoints Cloud v3
+ * 
+ * Setup:
+ * export UMAMI_CLOUD_API_KEY="your-api-key"
+ * 
+ * Run:
+ * source env/initenv_cloud.dontpush.sh
+ * node tests/manual/test_v3_cloud_endpoints.js
+ */
+
+import UmamiClient from '../../lib/export.js';
+
+const testAllEndpoints = async () => {
+    console.log('🧪 Test complet Umami v3 Cloud - Tous les endpoints\n');
+    
+    const results = {
+        compatible: [],
+        breaking: [],
+        errors: []
+    };
+    
+    try {
+        // Init client
+        const client = new UmamiClient();
+        console.log('✅ Client initialized\n');
+        
+        // Get first website for tests
+        const websites = await client.websites();
+        if (websites.length === 0) {
+            throw new Error('No websites found. Cannot test endpoints.');
+        }
+        
+        const site = websites[0];
+        console.log(`📊 Testing with website: ${site.name} (${site.domain})\n`);
+        console.log('─'.repeat(80));
+        
+        // ===== TEST 1: websiteStats =====
+        console.log('\n1️⃣  Testing websiteStats(id, "24h")...');
+        try {
+            const stats = await client.websiteStats(site.id, '24h');
+            console.log('   ✅ Request successful');
+            console.log('   📋 Structure:');
+            console.log(JSON.stringify(stats, null, 6));
+            
+            // Check structure
+            if (typeof stats.pageviews === 'number') {
+                results.breaking.push({
+                    method: 'websiteStats',
+                    reason: 'Values are now direct numbers (not objects with .value)',
+                    v2: '{ pageviews: { value: X } }',
+                    v3: '{ pageviews: X }'
+                });
+                console.log('   ⚠️  BREAKING: Values are direct numbers (v2 had .value)');
+            }
+            if (stats.comparison) {
+                results.breaking.push({
+                    method: 'websiteStats',
+                    reason: 'New field: comparison (period comparison)',
+                    added: 'comparison object'
+                });
+                console.log('   ℹ️  NEW: comparison field added');
+            }
+        } catch (error) {
+            results.errors.push({ method: 'websiteStats', error: error.message });
+            console.log(`   ❌ ERROR: ${error.message}`);
+        }
+        
+        console.log('\n' + '─'.repeat(80));
+        
+        // ===== TEST 2: websitePageViews =====
+        console.log('\n2️⃣  Testing websitePageViews(id, "24h", {unit: "hour"})...');
+        try {
+            const pageviews = await client.websitePageViews(site.id, '24h', {
+                unit: 'hour',
+                timezone: 'Europe/Paris'
+            });
+            console.log('   ✅ Request successful');
+            console.log('   📋 Structure:');
+            console.log(JSON.stringify(pageviews, null, 6));
+            
+            // Check if structure changed
+            if (Array.isArray(pageviews)) {
+                if (pageviews.length > 0) {
+                    const first = pageviews[0];
+                    console.log('   ℹ️  First item keys:', Object.keys(first));
+                }
+                results.compatible.push({ method: 'websitePageViews', note: 'Array structure maintained' });
+            } else {
+                results.breaking.push({
+                    method: 'websitePageViews',
+                    reason: 'Structure changed from v2',
+                    structure: typeof pageviews
+                });
+            }
+        } catch (error) {
+            results.errors.push({ method: 'websitePageViews', error: error.message });
+            console.log(`   ❌ ERROR: ${error.message}`);
+        }
+        
+        console.log('\n' + '─'.repeat(80));
+        
+        // ===== TEST 3: websiteMetrics =====
+        console.log('\n3️⃣  Testing websiteMetrics(id, "24h", {type: "path"})...');
+        try {
+            const metricsPath = await client.websiteMetrics(site.id, '24h', {
+                type: 'path',
+                unit: 'hour',
+                timezone: 'Europe/Paris'
+            });
+            console.log('   ✅ Request successful');
+            console.log('   📋 Structure (first 3 items):');
+            console.log(JSON.stringify(metricsPath?.slice(0, 3) || metricsPath, null, 6));
+
+            if (Array.isArray(metricsPath)) {
+                results.compatible.push({ method: 'websiteMetrics (path)', note: 'Array structure OK' });
+            }
+        } catch (error) {
+            results.errors.push({ method: 'websiteMetrics (path)', error: error.message });
+            console.log(`   ❌ ERROR: ${error.message}`);
+        }
+        
+        console.log('\n' + '─'.repeat(80));
+        
+        // ===== TEST 4: websiteMetrics (event) =====
+        console.log('\n4️⃣  Testing websiteMetrics(id, "24h", {type: "event"})...');
+        try {
+            const metricsEvent = await client.websiteMetrics(site.id, '24h', {
+                type: 'event',
+                unit: 'hour',
+                timezone: 'Europe/Paris'
+            });
+            console.log('   ✅ Request successful');
+            console.log('   📋 Structure (first 3 items):');
+            console.log(JSON.stringify(metricsEvent?.slice(0, 3) || metricsEvent, null, 6));
+            
+            if (Array.isArray(metricsEvent)) {
+                results.compatible.push({ method: 'websiteMetrics (event)', note: 'Array structure OK' });
+            }
+        } catch (error) {
+            results.errors.push({ method: 'websiteMetrics (event)', error: error.message });
+            console.log(`   ❌ ERROR: ${error.message}`);
+        }
+        
+        console.log('\n' + '─'.repeat(80));
+        
+        // ===== TEST 5: websiteEvents =====
+        console.log('\n5️⃣  Testing websiteEvents(id, "24h")...');
+        try {
+            const events = await client.websiteEvents(site.id, '24h', {
+                pageSize: 10
+            });
+            console.log('   ✅ Request successful');
+            console.log('   📋 Structure:');
+            console.log(JSON.stringify(events, null, 6));
+            
+            if (events.data && Array.isArray(events.data)) {
+                results.compatible.push({ method: 'websiteEvents', note: 'Paginated structure OK' });
+                console.log(`   ℹ️  Found ${events.data.length} events (paginated)`);
+            }
+        } catch (error) {
+            results.errors.push({ method: 'websiteEvents', error: error.message });
+            console.log(`   ❌ ERROR: ${error.message}`);
+        }
+        
+        console.log('\n' + '─'.repeat(80));
+        
+        // ===== TEST 6: websiteSessions =====
+        console.log('\n6️⃣  Testing websiteSessions(id, "24h")...');
+        try {
+            const sessions = await client.websiteSessions(site.id, '24h', {
+                pageSize: 5,
+                orderBy: '-createdAt'
+            });
+            console.log('   ✅ Request successful');
+            console.log('   📋 Structure:');
+            console.log(JSON.stringify(sessions, null, 6));
+            
+            if (sessions.data && Array.isArray(sessions.data)) {
+                results.compatible.push({ method: 'websiteSessions', note: 'Paginated structure OK' });
+                console.log(`   ℹ️  Found ${sessions.data.length} sessions (paginated)`);
+            }
+        } catch (error) {
+            results.errors.push({ method: 'websiteSessions', error: error.message });
+            console.log(`   ❌ ERROR: ${error.message}`);
+        }
+        
+        console.log('\n' + '─'.repeat(80));
+        
+        // ===== SUMMARY =====
+        console.log('\n\n📊 TEST SUMMARY\n');
+        console.log('═'.repeat(80));
+        
+        console.log(`\n✅ COMPATIBLE (${results.compatible.length}):`);
+        results.compatible.forEach(r => {
+            console.log(`   - ${r.method}: ${r.note}`);
+        });
+        
+        console.log(`\n⚠️  BREAKING CHANGES (${results.breaking.length}):`);
+        results.breaking.forEach(r => {
+            console.log(`   - ${r.method}: ${r.reason}`);
+            if (r.v2) console.log(`     v2: ${r.v2}`);
+            if (r.v3) console.log(`     v3: ${r.v3}`);
+            if (r.added) console.log(`     Added: ${r.added}`);
+        });
+        
+        console.log(`\n❌ ERRORS (${results.errors.length}):`);
+        if (results.errors.length === 0) {
+            console.log('   None! 🎉');
+        } else {
+            results.errors.forEach(r => {
+                console.log(`   - ${r.method}: ${r.error}`);
+            });
+        }
+        
+        console.log('\n' + '═'.repeat(80));
+        
+        if (results.errors.length === 0) {
+            console.log('\n✅ ALL ENDPOINTS TESTED SUCCESSFULLY! 🎉');
+        } else {
+            console.log('\n⚠️  Some endpoints failed. See errors above.');
+        }
+        
+    } catch (error) {
+        console.error('\n❌ FATAL ERROR!');
+        console.error(`Error: ${error.message}`);
+        console.error('\nStack:', error.stack);
+        process.exit(1);
+    }
+};
+
+// Run test
+testAllEndpoints().then(() => {
+    console.log('\n✨ Test completed');
+    process.exit(0);
+}).catch(err => {
+    console.error('\n💥 Unhandled error:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
⚠️ BREAKING CHANGES
This version targets Umami v3.x API only. Not compatible with Umami v2.x.

Stay on v2: Use umami-api-client@2.17.3 with Umami v2.x servers
Upgrade to v3: Use umami-api-client@3.0.3 with Umami v3.x servers
📚 Migration guide: See MIGRATION_V3.md

🚀 What's Changed
Core API
✅ Metric type renamed: url → path in websiteMetrics() (Umami v3 breaking change)
✅ Removed deprecated methods: getSites(), getStats(), getPageViews(), etc. → Use modern website*() equivalents
✅ Tests: 11/11 passing against Umami v3 API
Documentation
📘 MIGRATION_V3.md: Complete v2→v3 migration guide
📋 CHANGELOG.md: Version history (Keep a Changelog format)
📝 Updated README with version notice & migration link
Dependencies & Security
📦 Bumped to v3.0.3
⬆️ Updated: query-string, winston, mocha, chai v6, pnpm 10.28.1
🔒 0 vulnerabilities (fixed 2 CVE via overrides)
CI/CD
⬆️ GitHub Actions: checkout v6, setup-node v6, pnpm-action v4.2.0
📊 Stats
23 files changed, 1596 insertions(+), 442 deletions(-)

Issue #43